### PR TITLE
V3 fixes

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -3,6 +3,8 @@
 RColorBrewer palettes are inlined as hex (Set3 / Set1), matching v2 output exactly.
 """
 
+import os
+
 # Input validation
 MANDATORY_NETWORK_COLUMNS = ["SourceNode", "SourceLayer", "TargetNode", "TargetLayer"]
 OPTIONAL_NETWORK_COLUMNS = ["Channel", "Weight"]
@@ -10,9 +12,19 @@ MANDATORY_JSON_OBJECTS = ["layers", "nodes", "edges"]
 OPTIONAL_JSON_OBJECTS = ["scene", "universalLabelColor", "direction", "edgeOpacityByWeight"]
 MANDATORY_JSON_NODE_COLUMNS = ["name", "layer"]
 MANDATORY_JSON_EDGE_COLUMNS = ["src", "trg"]
-MAX_EDGES = 10_000
+# DoS fix: MAX_EDGES/MAX_NODES used to be enforced only by the TSV-upload
+# parser, leaving /api/layout, /api/topology, /api/session/import and
+# /api/external free to accept unbounded graphs. Env-overridable so
+# deployments can size limits to their hardware without a code change
+# (docker-compose.yml sets these for local dev/prod).
+MAX_EDGES = int(os.environ.get("ARENA_MAX_EDGES", "10000"))
+MAX_NODES = int(os.environ.get("ARENA_MAX_NODES", "20000"))
 MAX_CHANNELS = 9
 MAX_LAYERS = 18
+# DoS fix: caps request-body size for TSV/JSON uploads (bare uvicorn has no
+# built-in limit; nginx's client_max_body_size only covers the prod Docker
+# image, not local/dev deployments).
+MAX_UPLOAD_BYTES = int(os.environ.get("ARENA_MAX_UPLOAD_BYTES", str(20 * 1024 * 1024)))
 
 # Topology scaling
 DEFAULT_MAP_VALUE = 0.3

--- a/backend/app/models/layout.py
+++ b/backend/app/models/layout.py
@@ -2,8 +2,9 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from app import config
 from app.models.network import EdgeModel, NodeModel
 
 Scope = Literal["perLayer", "allLayers", "nodesPerLayers"]
@@ -15,8 +16,12 @@ class ClusteringOptions(BaseModel):
 
 
 class LayoutRequest(BaseModel):
-    nodes: list[NodeModel]
-    edges: list[EdgeModel]
+    # Unauthenticated DoS fix: this endpoint is reachable directly (not just via
+    # the TSV-upload flow), so the MAX_EDGES/MAX_NODES cap must be enforced here
+    # too, or a caller can force an O(V*E) layout algorithm over an arbitrarily
+    # large graph.
+    nodes: list[NodeModel] = Field(max_length=config.MAX_NODES)
+    edges: list[EdgeModel] = Field(max_length=config.MAX_EDGES)
     algorithm: str
     scope: Scope = "perLayer"
     selected_layers: list[str]

--- a/backend/app/models/topology.py
+++ b/backend/app/models/topology.py
@@ -2,16 +2,19 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from app import config
 from app.models.network import EdgeModel, NodeModel
 
 Scope = Literal["perLayer", "allLayers", "nodesPerLayers"]
 
 
 class TopologyRequest(BaseModel):
-    nodes: list[NodeModel]
-    edges: list[EdgeModel]
+    # Same unauthenticated-DoS fix as LayoutRequest — Betweenness Centrality is
+    # O(V*E) and this endpoint had no size limit of its own.
+    nodes: list[NodeModel] = Field(max_length=config.MAX_NODES)
+    edges: list[EdgeModel] = Field(max_length=config.MAX_EDGES)
     metric: str  # Degree | Clustering Coefficient | Betweenness Centrality
     scope: Scope = "perLayer"
     selected_layers: list[str]

--- a/backend/app/routers/attributes.py
+++ b/backend/app/routers/attributes.py
@@ -5,6 +5,7 @@ Replaces handleInput{Node,Edge}AttributeFileUpload() (functions/input.R).
 
 from fastapi import APIRouter, HTTPException, UploadFile
 
+from app import config
 from app.models.attributes import EdgeAttributeRow, NodeAttributeRow
 from app.services.attributes import parse_edge_attributes_tsv, parse_node_attributes_tsv
 from app.services.parser import NetworkValidationError
@@ -12,9 +13,18 @@ from app.services.parser import NetworkValidationError
 router = APIRouter()
 
 
+async def _read_capped(file: UploadFile) -> str:
+    """DoS fix: bound upload size in-app, since bare uvicorn (no nginx in
+    front, e.g. local/dev) enforces no request-body limit of its own."""
+    raw_bytes = await file.read()
+    if len(raw_bytes) > config.MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File too large.")
+    return raw_bytes.decode("utf-8", errors="replace")
+
+
 @router.post("/api/attributes/nodes", response_model=list[NodeAttributeRow])
 async def upload_node_attributes(file: UploadFile) -> list[NodeAttributeRow]:
-    raw = (await file.read()).decode("utf-8", errors="replace")
+    raw = await _read_capped(file)
     try:
         return parse_node_attributes_tsv(raw)
     except NetworkValidationError as e:
@@ -23,7 +33,7 @@ async def upload_node_attributes(file: UploadFile) -> list[NodeAttributeRow]:
 
 @router.post("/api/attributes/edges", response_model=list[EdgeAttributeRow])
 async def upload_edge_attributes(file: UploadFile) -> list[EdgeAttributeRow]:
-    raw = (await file.read()).decode("utf-8", errors="replace")
+    raw = await _read_capped(file)
     try:
         return parse_edge_attributes_tsv(raw)
     except NetworkValidationError as e:

--- a/backend/app/routers/external.py
+++ b/backend/app/routers/external.py
@@ -43,6 +43,13 @@ def _sweep() -> None:
 
 @router.post("/api/external", response_model=ExternalCreateResponse)
 async def create_external(session: dict[str, Any]) -> ExternalCreateResponse:
+    # DoS fix: validate (incl. MAX_NODES/MAX_EDGES) before anything touches
+    # disk — this endpoint used to write any payload straight to disk
+    # unvalidated, letting a caller fill server storage with oversized sessions.
+    try:
+        normalize_session(session)
+    except SessionValidationError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     os.makedirs(config.TMP_PATH, exist_ok=True)
     _sweep()
     token = secrets.token_urlsafe(16)

--- a/backend/app/routers/network.py
+++ b/backend/app/routers/network.py
@@ -2,6 +2,7 @@
 
 from fastapi import APIRouter, HTTPException, UploadFile
 
+from app import config
 from app.models.network import NetworkModel
 from app.services.parser import NetworkValidationError, parse_network_tsv
 
@@ -10,7 +11,12 @@ router = APIRouter()
 
 @router.post("/api/network", response_model=NetworkModel)
 async def upload_network(file: UploadFile) -> NetworkModel:
-    raw = (await file.read()).decode("utf-8", errors="replace")
+    raw_bytes = await file.read()
+    # DoS fix: reject oversized uploads before pandas parses the whole file
+    # into memory — MAX_EDGES was only checked *after* the parse completed.
+    if len(raw_bytes) > config.MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File too large.")
+    raw = raw_bytes.decode("utf-8", errors="replace")
     try:
         return parse_network_tsv(raw)
     except NetworkValidationError as e:

--- a/backend/app/routers/session.py
+++ b/backend/app/routers/session.py
@@ -11,6 +11,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
 
+from app import config
 from app.models.session import SessionImportResponse
 from app.services.session import SessionValidationError, normalize_session
 
@@ -19,8 +20,12 @@ router = APIRouter()
 
 @router.post("/api/session/import", response_model=SessionImportResponse)
 async def import_session(file: UploadFile) -> SessionImportResponse:
+    raw_bytes = await file.read()
+    # DoS fix: same upload-size cap as /api/network — see routers/attributes.py.
+    if len(raw_bytes) > config.MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File too large.")
     try:
-        data = json.loads((await file.read()).decode("utf-8", errors="replace"))
+        data = json.loads(raw_bytes.decode("utf-8", errors="replace"))
     except json.JSONDecodeError as e:
         raise HTTPException(status_code=400, detail="Bad imported network file format.") from e
     try:

--- a/backend/app/services/session.py
+++ b/backend/app/services/session.py
@@ -49,6 +49,12 @@ def _validate(data: dict[str, Any]) -> None:
             f"The network must contain no more than {config.MAX_LAYERS} layers."
         )
     nodes = data["nodes"]
+    # DoS fix: unlike the TSV upload path (parser.py), JSON session import and
+    # the /api/external hand-off had no node/edge count limit at all.
+    if len(nodes) > config.MAX_NODES:
+        raise SessionValidationError(
+            f"The network must contain no more than {config.MAX_NODES} nodes."
+        )
     if any(_empty(n.get("name")) or _empty(n.get("layer")) for n in nodes):
         raise SessionValidationError("JSON nodes must each have a non-empty name and layer.")
     # Referential integrity: the frontend parents every node to layerGroups[layer]
@@ -60,6 +66,11 @@ def _validate(data: dict[str, Any]) -> None:
         raise SessionValidationError(f"JSON node references unknown layer '{bad_layer}'.")
     node_ids = {f"{n['name']}_{n['layer']}" for n in nodes}
     edges = data["edges"]
+    # Same DoS fix as the node-count check above, for edges.
+    if len(edges) > config.MAX_EDGES:
+        raise SessionValidationError(
+            f"The network must contain no more than {config.MAX_EDGES} edges."
+        )
     if any(_empty(e.get("src")) or _empty(e.get("trg")) for e in edges):
         raise SessionValidationError("JSON edges must each have a non-empty src and trg.")
     bad_edge = next(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,12 @@ services:
     command: sh -c "npm install && npm run dev -- --host"
     environment:
       - VITE_PROXY_TARGET=http://backend:8000
+      # Fix for Vite's "Blocked request" host-check error when this dev
+      # server is reverse-proxied under a public domain — see vite.config.ts.
+      - VITE_ALLOWED_HOSTS=pavlopoulos-lab-services.org
+      # Sub-path deployment fix: matches the Apache ProxyPass prefix
+      # (/arena3/) so generated asset URLs resolve through the proxy.
+      - VITE_BASE_PATH=/arena3/
     ports:
       - "5173:5173"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
       - ./backend:/app
       - backend-venv:/app/.venv
     command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    # Explicit here (matching config.py's defaults) so the resource-limit DoS
+    # fix is deployment-tunable without editing code — see backend/app/config.py.
+    environment:
+      - ARENA_MAX_EDGES=10000
+      - ARENA_MAX_NODES=20000
     ports:
       - "8000:8000"
 

--- a/frontend/src/actions/right_click_menu.ts
+++ b/frontend/src/actions/right_click_menu.ts
@@ -225,6 +225,14 @@ function showDescription(descr: string): void {
   descrDiv.style.display = 'inline-block'
 }
 
+// XSS fix: only http(s)/mailto — blocks javascript:/data: payloads smuggled
+// in via an uploaded node-attributes file's Url column. noopener/noreferrer
+// so the opened tab can't reach back into this window via window.opener.
+function openNodeLink(url: string): void {
+  if (!/^(https?:|mailto:)/i.test(url.trim())) return
+  window.open(url, '_blank', 'noopener,noreferrer')
+}
+
 export function executeCommand(nodeIndex: number, option: string): void {
   const node = ctx.nodeObjects[nodeIndex]
   if (option === '-') return
@@ -232,7 +240,7 @@ export function executeCommand(nodeIndex: number, option: string): void {
   if (option === 'Select Neighbors') selectNeighbors(nodeIndex)
   else if (option === 'Select MultiLayer Path') selectMultiLayerPath(nodeIndex)
   else if (option === 'Select Downstream Path') selectDownstreamPath(nodeIndex)
-  else if (option === 'Link') window.open(node.url)
+  else if (option === 'Link') openNodeLink(node.url)
   else if (option === 'Description') showDescription(node.descr)
 
   finishCommand()

--- a/frontend/src/ui/data.ts
+++ b/frontend/src/ui/data.ts
@@ -10,6 +10,7 @@ import { Tab } from 'bootstrap'
 import { bus } from '../bus'
 import { store } from '../store'
 import { ctx } from '../three'
+import { escapeHtml } from '../utils'
 
 const TABS = [
   { id: 'network', label: 'Network Data' },
@@ -44,13 +45,6 @@ const DATA_HTML = `
 </div>
 `
 
-function esc(v: string | number): string {
-  return String(v)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-}
-
 function toCsv(columns: string[], rows: (string | number)[][]): string {
   const q = (v: string | number) => {
     const s = String(v)
@@ -78,9 +72,9 @@ function renderTable(
     <button class="btn btn-sm btn-secondary mb-2" id="dataCsv-${tabId}">Download CSV</button>
     <div style="max-height: 70vh; overflow: auto;">
       <table class="table table-dark table-striped table-sm">
-        <thead><tr>${columns.map((c) => `<th>${esc(c)}</th>`).join('')}</tr></thead>
+        <thead><tr>${columns.map((c) => `<th>${escapeHtml(c)}</th>`).join('')}</tr></thead>
         <tbody>${rows
-          .map((r) => `<tr>${r.map((v) => `<td>${esc(v)}</td>`).join('')}</tr>`)
+          .map((r) => `<tr>${r.map((v) => `<td>${escapeHtml(v)}</td>`).join('')}</tr>`)
           .join('')}</tbody>
       </table>
     </div>`

--- a/frontend/src/ui/data.ts
+++ b/frontend/src/ui/data.ts
@@ -74,7 +74,10 @@ function renderTable(
       <table class="table table-dark table-striped table-sm">
         <thead><tr>${columns.map((c) => `<th>${escapeHtml(c)}</th>`).join('')}</tr></thead>
         <tbody>${rows
-          .map((r) => `<tr>${r.map((v) => `<td>${escapeHtml(v)}</td>`).join('')}</tr>`)
+          .map(
+            (r) =>
+              `<tr>${r.map((v) => `<td>${escapeHtml(v)}</td>`).join('')}</tr>`
+          )
           .join('')}</tbody>
       </table>
     </div>`

--- a/frontend/src/ui/edge.ts
+++ b/frontend/src/ui/edge.ts
@@ -21,6 +21,7 @@ import {
   setEdgeFileColorPriority,
   setChannelVisibility,
 } from '../actions/edge'
+import { escapeHtml } from '../utils'
 
 const EDGE_HTML = `
 <div class="col-md-6 col-lg-4">
@@ -73,6 +74,9 @@ function show(id: string, visible: boolean): void {
 }
 
 // v2 attachChannelEditList: per channel a color picker + a Hide checkbox.
+// XSS fix: `ch` is a user-controlled channel name (TSV Channel column) —
+// escapeHtml() it before interpolating into innerHTML, including inside the
+// id/value attributes below.
 function buildChannelEditList(): void {
   const container = document.getElementById('channelColorPicker')
   if (!container) return
@@ -88,10 +92,10 @@ function buildChannelEditList(): void {
     const row = document.createElement('div')
     row.className = 'channel_subcontainer d-flex align-items-center gap-2 mb-2'
     row.innerHTML = `
-      <span class="channelLabel">${ch}:</span>
-      <input type="color" class="colorPicker channel_colorPicker" id="color${ch}" value="${ctx.channelColors[ch] ?? '#cfcfcf'}" />
-      <input class="form-check-input channel_checkbox" type="checkbox" id="checkbox${ch}" />
-      <label class="channelCheckboxLabel" for="checkbox${ch}">Hide</label>
+      <span class="channelLabel">${escapeHtml(ch)}:</span>
+      <input type="color" class="colorPicker channel_colorPicker" id="color${escapeHtml(ch)}" value="${ctx.channelColors[ch] ?? '#cfcfcf'}" />
+      <input class="form-check-input channel_checkbox" type="checkbox" id="checkbox${escapeHtml(ch)}" />
+      <label class="channelCheckboxLabel" for="checkbox${escapeHtml(ch)}">Hide</label>
     `
     const picker = row.querySelector<HTMLInputElement>('.channel_colorPicker')!
     const hide = row.querySelector<HTMLInputElement>('.channel_checkbox')!

--- a/frontend/src/ui/file.ts
+++ b/frontend/src/ui/file.ts
@@ -76,7 +76,14 @@ async function onLoadSession(file: File): Promise<void> {
 
 async function onLoadExample(): Promise<void> {
   try {
-    const res = await fetch('/example_network.tsv')
+    // Sub-path deployment fix: this is a hardcoded root-absolute fetch, so
+    // Vite's `base` rewriting (which only covers Vite-generated asset/HTML
+    // URLs) doesn't apply here — prefix it manually via BASE_URL so it still
+    // resolves under a reverse-proxied sub-path (e.g. /arena3/). Without the
+    // res.ok check, a 404 here would silently POST the error page's body to
+    // /api/network as if it were the TSV.
+    const res = await fetch(`${import.meta.env.BASE_URL}example_network.tsv`)
+    if (!res.ok) throw new Error(`Failed to fetch example network: ${res.status}`)
     const file = new File([await res.blob()], 'example_network.tsv', {
       type: 'text/tab-separated-values',
     })

--- a/frontend/src/ui/file.ts
+++ b/frontend/src/ui/file.ts
@@ -83,7 +83,8 @@ async function onLoadExample(): Promise<void> {
     // res.ok check, a 404 here would silently POST the error page's body to
     // /api/network as if it were the TSV.
     const res = await fetch(`${import.meta.env.BASE_URL}example_network.tsv`)
-    if (!res.ok) throw new Error(`Failed to fetch example network: ${res.status}`)
+    if (!res.ok)
+      throw new Error(`Failed to fetch example network: ${res.status}`)
     const file = new File([await res.blob()], 'example_network.tsv', {
       type: 'text/tab-separated-values',
     })

--- a/frontend/src/ui/help.ts
+++ b/frontend/src/ui/help.ts
@@ -23,7 +23,7 @@ const HELP_HTML = `
   <p>This is the action panel that allows the user to upload network data as well as export the network in its current
     state.</p> <br />
   <p>
-    <img src="/images/help/file.png" alt="File Actions"
+    <img src="${import.meta.env.BASE_URL}images/help/file.png" alt="File Actions"
       style="float:left;width:282px;height:425px;margin:5px;margin-right:20px;">
     <span class="numbering"> 1.</span> The <i> Upload Network </i> option allows the user to upload network data in the
     Arena3D format. This file consists of 4 mandatory columns with headers <b><i>SourceNode, TargetNode,
@@ -221,8 +221,8 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
     in Arena3D.
     Take this aspirin network example, designed in Cytoscape via the StringApp.
   </p>
-  <img src="/images/help/cytoscape_aspirin.png" alt="Cytoscape example" style="float:left;width:1200px;max-width:100%;">
-  <img src="/images/help/arena3dapp.png" alt="ArenaApp prompt window" style="float:left;width:500px;max-width:100%;">
+  <img src="${import.meta.env.BASE_URL}images/help/cytoscape_aspirin.png" alt="Cytoscape example" style="float:left;width:1200px;max-width:100%;">
+  <img src="${import.meta.env.BASE_URL}images/help/arena3dapp.png" alt="ArenaApp prompt window" style="float:left;width:500px;max-width:100%;">
   <p>
     The Arena3D<sup>web</sup>App prompt window asks for layer and description information in its dedicated panel.
     The most important setting is choosing which node attribute contains the layer information.
@@ -242,7 +242,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
     it in Arena3D.
     The generated Arena3D should look something like this:
   </p>
-  <img src="/images/help/arena_cytoscape_aspirin.png" alt="Arena Cytoscape Integration"
+  <img src="${import.meta.env.BASE_URL}images/help/arena_cytoscape_aspirin.png" alt="Arena Cytoscape Integration"
     style="float:left;width:1200px;max-width:100%;">
   <p class="last_p"></p>
 </div>
@@ -253,65 +253,65 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
 
   <p>
     <b>Random networks with different topologies mapped in 6 layers respectively: </b> <br />
-    The <a href="/data/figure1_data.tsv" download>example network</a> in the Arena3D format. <br />
-    An <a href="/data/figure1_export.json" download>exported state file</a> of this example. <br />
+    The <a href="${import.meta.env.BASE_URL}data/figure1_data.tsv" download>example network</a> in the Arena3D format. <br />
+    An <a href="${import.meta.env.BASE_URL}data/figure1_export.json" download>exported state file</a> of this example. <br />
   </p>
   <hr>
   <p>
     <b>Network example with 4 layers: </b> <br />
-    The <a href="/data/figure2A_data.tsv" download>network file</a> in Arena3D input format. <br />
-    An <a href="/data/figure2A_export.json" download>exported state file</a> of this example forming a cube in 3D space. <br />
+    The <a href="${import.meta.env.BASE_URL}data/figure2A_data.tsv" download>network file</a> in Arena3D input format. <br />
+    An <a href="${import.meta.env.BASE_URL}data/figure2A_export.json" download>exported state file</a> of this example forming a cube in 3D space. <br />
   </p>
   <hr>
   <p>
     <b>Another network example with 4 layers, accompanied by node and edge attribute files: </b> <br />
-    The <a href="/data/figure2B_data.tsv" download>network file</a> in Arena3D input format. <br />
-    <a href="/data/figure2B_data_node_attributes.tsv" download>Node attributes file</a> for this example.<br />
-    <a href="/data/figure2B_data_edge_attributes.tsv" download>Edge attributes file</a> for this example. <br />
-    An <a href="/data/figure2B_export.json" download>exported state file</a> of this example. <br />
+    The <a href="${import.meta.env.BASE_URL}data/figure2B_data.tsv" download>network file</a> in Arena3D input format. <br />
+    <a href="${import.meta.env.BASE_URL}data/figure2B_data_node_attributes.tsv" download>Node attributes file</a> for this example.<br />
+    <a href="${import.meta.env.BASE_URL}data/figure2B_data_edge_attributes.tsv" download>Edge attributes file</a> for this example. <br />
+    An <a href="${import.meta.env.BASE_URL}data/figure2B_export.json" download>exported state file</a> of this example. <br />
   </p>
   <hr>
   <p>
     <b>SARS-CoV-2 example: </b> <br />
-    A <a href="/data/covid19_data.tsv" download>Covid-19 network</a> based on the work of
+    A <a href="${import.meta.env.BASE_URL}data/covid19_data.tsv" download>Covid-19 network</a> based on the work of
     <a href="https://www.nature.com/articles/s41586-020-2286-9" target="_blank">Gordon et al.</a>,
     in the Arena3D format. <br />
-    <a href="/data/covid19_data_node_attributes.tsv" download>Node attributes file</a> for this example.<br />
-    <a href="/data/covid19_data_edge_attributes.tsv" download>Edge attributes file</a> for this example.<br />
-    An <a href="/data/covid19_export.json" download>exported state file</a> of this example. <br />
+    <a href="${import.meta.env.BASE_URL}data/covid19_data_node_attributes.tsv" download>Node attributes file</a> for this example.<br />
+    <a href="${import.meta.env.BASE_URL}data/covid19_data_edge_attributes.tsv" download>Edge attributes file</a> for this example.<br />
+    An <a href="${import.meta.env.BASE_URL}data/covid19_export.json" download>exported state file</a> of this example. <br />
   </p>
   <hr>
   <p>
     <b>GPCR example: </b> <br />
-    The <a href="/data/GPCRs_data.tsv" download>network file</a> in the Arena3D format. <br />
-    <a href="/data/GPCRs_data_node_attributes.tsv" download>Node attributes file</a> for this example.<br />
-    <a href="/data/GPCRs_data_edge_attributes.tsv" download>Edge attributes file</a> for this example.<br />
-    An <a href="/data/GPCRs_export.json" download>exported state file</a> of this example. <br />
+    The <a href="${import.meta.env.BASE_URL}data/GPCRs_data.tsv" download>network file</a> in the Arena3D format. <br />
+    <a href="${import.meta.env.BASE_URL}data/GPCRs_data_node_attributes.tsv" download>Node attributes file</a> for this example.<br />
+    <a href="${import.meta.env.BASE_URL}data/GPCRs_data_edge_attributes.tsv" download>Edge attributes file</a> for this example.<br />
+    An <a href="${import.meta.env.BASE_URL}data/GPCRs_export.json" download>exported state file</a> of this example. <br />
   </p>
   <hr>
   <p>
     <b>Aspirin network example with 3 data channels: </b> <br />
-    The <a href="/data/aspirin_3channels.tsv" download>network file</a> in the Arena3D format. <br />
-    An <a href="/data/aspirin_3channels_directed.json" download>exported state file</a> of this example. <br />
+    The <a href="${import.meta.env.BASE_URL}data/aspirin_3channels.tsv" download>network file</a> in the Arena3D format. <br />
+    An <a href="${import.meta.env.BASE_URL}data/aspirin_3channels_directed.json" download>exported state file</a> of this example. <br />
   </p>
   <hr>
   <p>
     <b><a href="https://imbbc.hcmr.gr/project/prego/" target="_blank"> PREGO </a> 3-channel example
       for 'anaerobic ammonium oxidation' process associations:</b> <br />
-    The <a href="/data/prego.tsv" download>network file</a> in the Arena3D format. <br />
-    An <a href="/data/prego.json" download>exported state file</a> of this example. <br />
+    The <a href="${import.meta.env.BASE_URL}data/prego.tsv" download>network file</a> in the Arena3D format. <br />
+    An <a href="${import.meta.env.BASE_URL}data/prego.json" download>exported state file</a> of this example. <br />
   </p>
   <hr>
   <p>
     <b>Cytoscape-Arena3D<sup>web</sup>App aspirin multi-channel interoperability example: </b> <br />
-    The <a href="/data/StringApp_aspirin.cys" download>network file</a> in Cytoscape format. <br />
-    An <a href="/data/Arena3DApp_aspirin.json" download>exported state file</a> of this example in the
+    The <a href="${import.meta.env.BASE_URL}data/StringApp_aspirin.cys" download>network file</a> in Cytoscape format. <br />
+    An <a href="${import.meta.env.BASE_URL}data/Arena3DApp_aspirin.json" download>exported state file</a> of this example in the
     Arena3D exported format. <br />
   </p>
   <hr>
   <p>
     <b>Scripts: </b> <br />
-    A <a href="/data/transpose.py" download> Python script</a> for parsing edgelist data into Arena3D
+    A <a href="${import.meta.env.BASE_URL}data/transpose.py" download> Python script</a> for parsing edgelist data into Arena3D
     format.<br />
     As an example, this input file:
   </p>
@@ -340,7 +340,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
   <p> This is the main panel for network transformations in 3D space. The actions are divided into 3 subsections,
     namely, Scene, Layers and Nodes.</p><br />
   <p class="last_p">
-    <img src="/images/help/navigation_panel.png" alt="Navigation Panel"
+    <img src="${import.meta.env.BASE_URL}images/help/navigation_panel.png" alt="Navigation Panel"
       style="float:left;width:280px;height:1152px;max-width:100%;margin:5px;margin-right:20px;">
     <b>General</b> <br />
     <span class="numbering"> 1.</span> The <i> Navigation Controls </i> button is used to hide/show the navigation
@@ -398,7 +398,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
     apply layout and clustering algorithms and node scaling based on network metrics, on subgraphs of the network.</p>
   <br />
   <p>
-    <img src="/images/help/layouts.png" alt="Layouts"
+    <img src="${import.meta.env.BASE_URL}images/help/layouts.png" alt="Layouts"
       style="float:left;width:360px;height:518px;max-width:100%;margin:5px;margin-right:20px;">
     <span class="numbering"> 1. </span> This consists of a group of 3 exclusive options for subgraph calculations, upon
       which, layout algorithms (<span class="numbering">3, 5</span>), clustering algorithms (<span
@@ -455,7 +455,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
       Harel.</li>
   </ul>
 
-  <img src="/images/help/layouts_figure.png" alt="Layouts Figure" style="float:left;height:75%;max-width:100%;">
+  <img src="${import.meta.env.BASE_URL}images/help/layouts_figure.png" alt="Layouts Figure" style="float:left;height:75%;max-width:100%;">
 
   <p>Below, we briefly desribe the available clustering algorithms (<span class="numbering">4</span>).</p><br />
   <ul>
@@ -476,7 +476,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
       propagated to the unlabeled points throughout the course of the algorithm. </li>
   </ul>
 
-  <img src="/images/help/clustering.png" alt="Clustering" style="float:left;max-width:100%;">
+  <img src="${import.meta.env.BASE_URL}images/help/clustering.png" alt="Clustering" style="float:left;max-width:100%;">
 
   <p>Below, we briefly desribe the available network metrics for node scaling (<span class="numbering">6</span>).</p>
   <br />
@@ -497,7 +497,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
   <h2>Scene Actions</h2>
   <p> In this tab, the user has 2 scene-related options.</p><br />
   <p class="last_p">
-    <img src="/images/help/scene1_1.PNG" alt="Scene"
+    <img src="${import.meta.env.BASE_URL}images/help/scene1_1.PNG" alt="Scene"
       style="float:left;width:335px;height:333px;max-width:100%;margin:5px;margin-right:20px;">
     <span class="numbering"> 1. </span> A checkbox that toggles the visibility of the scene coordinates system. <br />
     <span class="numbering"> 2. </span> A checkbox that enables scene auto rotate. (The user must enable it and then
@@ -512,16 +512,16 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
   </p>
 
   <div class="scene-actions">
-    <img src="/images/help/predefined_layouts.png" alt="Predefined Layouts" style="float:left;height:35%;max-width:100%;">
+    <img src="${import.meta.env.BASE_URL}images/help/predefined_layouts.png" alt="Predefined Layouts" style="float:left;height:35%;max-width:100%;">
   </div>
 
-  <img src="/images/help/vr.png" alt="VR" style="height: 50%;max-width:100%;">
+  <img src="${import.meta.env.BASE_URL}images/help/vr.png" alt="VR" style="height: 50%;max-width:100%;">
 
   <p>
     A dedicated theme bar is also offered on the top-right corner of the UI, allowing the user to choose among a
     Light, a Dark and a Gray mode.
   </p>
-  <img src="/images/help/themes.png" alt="Themes" style="margin-bottom:50px;height:45%;max-width:100%;">
+  <img src="${import.meta.env.BASE_URL}images/help/themes.png" alt="Themes" style="margin-bottom:50px;height:45%;max-width:100%;">
   <p class="last_p"></p>
 </div>
 
@@ -530,7 +530,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
   <h2>Layers</h2>
   <p>This control panel incorporates layer-related actions.</p> <br />
   <p class="last_p">
-    <img src="/images/help/layers.png" alt="Layers"
+    <img src="${import.meta.env.BASE_URL}images/help/layers.png" alt="Layers"
       style="float:left;width:317px;height:434px;max-width:100%;margin:5px;margin-right:20px;">
     <span class="numbering"> 1. </span> This checkbox allows the user to show or hide all layer labels.<br />
     <span class="numbering"> 2. </span> This checkbox gives the option of showing the labels of selected layers only.
@@ -552,7 +552,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
   <h2>Nodes</h2>
   <p>This control panel incorporates node-related actions.</p> <br />
   <p>
-    <img src="/images/help/nodes.png" alt="Nodes"
+    <img src="${import.meta.env.BASE_URL}images/help/nodes.png" alt="Nodes"
       style="float:left;width:580px;height:358px;max-width:100%;margin:5px;margin-right:20px;">
     <span class="numbering"> 1. </span> This options allows the user to select/deselect all nodes. Selected nodes can
     then be translated in 3D space via the <i>Navigation Controls</i>, and via the <i>Layer Selection & Layouts</i>
@@ -575,7 +575,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
   </p>
   <br />
   <br />
-  <img src="/images/help/mainview.png" alt="Main View"
+  <img src="${import.meta.env.BASE_URL}images/help/mainview.png" alt="Main View"
     style="float:left;width:726px;height:555px;max-width:100%;margin:5px;margin-right:20px;">
   <ul class="last_p">
     <li>
@@ -598,7 +598,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
   <h2>Edges</h2>
   <p>This control panel incorporates edge-related actions.</p> <br />
   <p class="last_p">
-    <img src="/images/help/edges.png" alt="Edges"
+    <img src="${import.meta.env.BASE_URL}images/help/edges.png" alt="Edges"
       style="float:left;width:320px;height:auto;max-width:100%;margin:5px;margin-right:20px;">
     <span class="numbering"> 1. </span> This option highlights the selected edges.<br />
     <span class="numbering"> 2. </span> This option toggles gives priority to the edge color that it is set on file. If
@@ -632,9 +632,9 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
     This is visible only if option
     (<span class="numbering">2</span>) is not enabled.<br />
     <br />
-    <img src="/images/help/directed_graph.png" alt="Directed Graph"
+    <img src="${import.meta.env.BASE_URL}images/help/directed_graph.png" alt="Directed Graph"
       style="float:left;height:45%;max-width:100%;margin:5px;margin-right:20px;">
-    <img src="/images/help/channels.png" alt="Channels" style="float:left;height:50%;max-width:100%;margin:5px;margin-right:20px;">
+    <img src="${import.meta.env.BASE_URL}images/help/channels.png" alt="Channels" style="float:left;height:50%;max-width:100%;margin:5px;margin-right:20px;">
     <br />
   <p class="last_p"></p>
 </div>
@@ -643,7 +643,7 @@ Kn	        Group4	        Tn	        Group7	        #4EFB7D
 
   <h2>FPS</h2>
   <p class="last_p"> The option for frames per second. The user is allowed to choose between 3 options: <br /><br />
-    <img src="/images/help/fps2.PNG" alt="FPS"
+    <img src="${import.meta.env.BASE_URL}images/help/fps2.PNG" alt="FPS"
       style="float:left;width:284px;height:158px;max-width:100%;margin:5px;margin-right:20px;">
     &bull; 15FPS, for larger, more processing-heavy networks. <br />
     &bull; 30FPS, the default option. <br />

--- a/frontend/src/ui/home.ts
+++ b/frontend/src/ui/home.ts
@@ -11,7 +11,7 @@ const HOME_HTML = `
 
   <div class="home-grid">
     <figure class="home-figure">
-      <img src="/images/help/mainview2.png" alt="A multilayered network rendered across stacked 3D layers" class="img-fluid" />
+      <img src="${import.meta.env.BASE_URL}images/help/mainview2.png" alt="A multilayered network rendered across stacked 3D layers" class="img-fluid" />
     </figure>
     <div class="home-intro">
       <p>

--- a/frontend/src/ui/layouts.ts
+++ b/frontend/src/ui/layouts.ts
@@ -13,6 +13,7 @@ import {
   setLayerVisibility,
   setLayerNodeLabels,
 } from '../actions/layer'
+import { escapeHtml } from '../utils'
 import type { Scope } from '../api/client'
 
 // v2 views/layouts.R option lists (Davidson-Harel / GEM / Edge Betweenness
@@ -96,6 +97,8 @@ function status(msg: string, isError = false): void {
 
 // v2 attachLayerCheckboxes: per layer a select checkbox (labelled with the
 // layer name) plus Hide and Labels checkboxes.
+// XSS fix: layer.name comes straight from an uploaded TSV/session file, so it
+// must go through escapeHtml() before landing in the innerHTML template below.
 function buildLayerCheckboxes(): void {
   const container = document.getElementById('checkboxdiv')
   if (!container) return
@@ -105,7 +108,7 @@ function buildLayerCheckboxes(): void {
     row.className = 'layer-row'
     row.innerHTML = `
       <input class="form-check-input layer_checkbox" type="checkbox" id="checkbox_${i}" ${layer.isSelected ? 'checked' : ''} />
-      <label class="form-check-label layer_label layer-row__name" for="checkbox_${i}">${layer.name}</label>
+      <label class="form-check-label layer_label layer-row__name" for="checkbox_${i}">${escapeHtml(layer.name)}</label>
       <label class="form-check-label layer-row__opt" for="checkbox2_${i}">
         <input class="form-check-input hideLayer_checkbox" type="checkbox" id="checkbox2_${i}" />Hide</label>
       <label class="form-check-label layer-row__opt" for="checkbox3_${i}">
@@ -123,6 +126,8 @@ function buildLayerCheckboxes(): void {
 
 // v2 attachChannelLayoutList, minus the collapse toggle — all channels
 // checked by default; checked ones are sent as selected_channels.
+// XSS fix: channel names are user-controlled (TSV Channel column) — same
+// escapeHtml() treatment as buildLayerCheckboxes above.
 function buildChannelList(): void {
   const container = document.getElementById('channelColorLayoutDiv')
   if (!container) return
@@ -137,8 +142,8 @@ function buildChannelList(): void {
     const row = document.createElement('div')
     row.className = 'form-check'
     row.innerHTML = `
-      <input class="form-check-input channel_checkbox" type="checkbox" id="checkbox_layout${ch}" checked />
-      <label class="form-check-label" for="checkbox_layout${ch}">${ch}</label>
+      <input class="form-check-input channel_checkbox" type="checkbox" id="checkbox_layout${escapeHtml(ch)}" checked />
+      <label class="form-check-label" for="checkbox_layout${escapeHtml(ch)}">${escapeHtml(ch)}</label>
     `
     container.appendChild(row)
   }

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,5 +1,16 @@
 // General utilities — port of v2 www/js/general.js. Pure, framework-free.
 
+// XSS fix: escapes HTML metacharacters so user-controlled strings
+// (layer/channel names from uploaded network files) can't break out of an
+// innerHTML template. Shared by ui/data.ts, ui/edge.ts, ui/layouts.ts.
+export function escapeHtml(v: string | number): string {
+  return String(v)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
 export function exists<T>(array: T[], element: T): boolean {
   return array.some((l) => l == element)
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,7 +1,20 @@
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  // Sub-path deployment fix: Vite emits root-absolute asset URLs (e.g.
+  // "/assets/x.js") by default, which 404 when the app is reverse-proxied
+  // under a path prefix (e.g. Apache's ProxyPass /arena3/ -> this server).
+  // Set via env so the prefix isn't baked into the repo per-deployment.
+  base: process.env.VITE_BASE_PATH ?? '/',
   server: {
+    // Vite's dev-server Host-header check (anti DNS-rebinding) rejects any
+    // request whose Host doesn't match localhost/an IP/an allowed entry.
+    // Deployments reverse-proxying a real domain to this dev server need
+    // their hostname listed here — set via env so it's not baked into the
+    // repo. Comma-separated (e.g. "example.org,example.org:8080").
+    allowedHosts: process.env.VITE_ALLOWED_HOSTS
+      ? process.env.VITE_ALLOWED_HOSTS.split(',').map((h) => h.trim())
+      : undefined,
     proxy: {
       // VITE_PROXY_TARGET set by docker-compose (backend service hostname)
       '/api': process.env.VITE_PROXY_TARGET ?? 'http://localhost:8000',

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,6 +17,10 @@ http {
         location / {
             root /usr/share/nginx/html;
             try_files $uri /index.html;
+            # XSS defense-in-depth: blocks inline/injected scripts even if an
+            # escaping fix is missed somewhere else (see the layer/channel-name
+            # and node-url XSS fixes in frontend/src/).
+            add_header Content-Security-Policy "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self';" always;
         }
     }
 }


### PR DESCRIPTION
### Security fixes
  - Stored XSS: layer/channel names from uploaded network files were injected unescaped into innerHTML (ui/data.ts, ui/edge.ts, ui/layouts.ts) — fixed via a shared escapeHtml() helper.
  - javascript: URL execution: the node "Link" context-menu action called window.open(node.url) with no protocol check — fixed with an http(s)/mailto allow-list + noopener,noreferrer.
  - Unauthenticated DoS: /api/layout, /api/topology, /api/session/import, and /api/external accepted unbounded node/edge payloads — fixed with MAX_EDGES/MAX_NODES limits enforced consistently across all
  endpoints (configurable via ARENA_MAX_EDGES/ARENA_MAX_NODES env vars).
  - Upload size DoS: file uploads were fully parsed before any size check — fixed with a MAX_UPLOAD_BYTES guard (413 response) on all upload routes.
  - CSP header added to nginx.conf as defense-in-depth against XSS.

### Sub-path deployment fixes
  - vite.config.ts: added base (from VITE_BASE_PATH env var) so bundled asset URLs resolve correctly under a reverse-proxied sub-path.
  - vite.config.ts: added server.allowedHosts (from VITE_ALLOWED_HOSTS env var) to fix Vite's dev-server "Blocked request" host-check error.
  - docker-compose.yml: wired VITE_BASE_PATH=/arena3/ and VITE_ALLOWED_HOSTS=pavlopoulos-lab-services.org into the frontend service.
  - ui/file.ts: onLoadExample()'s hardcoded fetch('/example_network.tsv') → prefixed with import.meta.env.BASE_URL, plus an res.ok check (previously a 404 page's HTML was silently POSTed to /api/network as if it
  were the TSV).
  - ui/help.ts: all 23 hardcoded /data/* example-file download links + all 19 hardcoded /images/help/*.png image sources → same BASE_URL prefix fix.
  - ui/home.ts: the Home panel's hardcoded /images/help/mainview2.png → same fix.
